### PR TITLE
fix: escape table name correctly and add schema name field

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -84,7 +84,7 @@ export const setupPlugin: PostgresPlugin['setupPlugin'] = async (meta) => {
     global.sanitizedTableName = sanitizeSqlIdentifier(config.tableName)
 
     const queryError = await executeQuery(
-        `CREATE TABLE IF NOT EXISTS public.${global.sanitizedTableName} (
+        `CREATE TABLE IF NOT EXISTS ${global.sanitizedTableName} (
             uuid varchar(200),
             event varchar(200),
             properties jsonb,
@@ -265,5 +265,5 @@ const executeQuery = async (query: string, values: any[], config: PostgresMeta['
 }
 
 const sanitizeSqlIdentifier = (unquotedIdentifier: string): string => {
-    return unquotedIdentifier.replace(/[^\w\d_]+/g, '')
+    return '"' + unquotedIdentifier.replace(/"/g, '""') + '"'
 }

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ type PostgresPlugin = Plugin<{
     global: {
         pgClient: Client
         eventsToIgnore: Set<string>
+        sanitizedSchemaName: string
         sanitizedTableName: string
     }
     config: {
@@ -12,6 +13,7 @@ type PostgresPlugin = Plugin<{
         host: string
         port: string
         dbName: string
+        schemaName: string
         tableName: string
         dbUsername: string
         dbPassword: string
@@ -81,10 +83,11 @@ export const setupPlugin: PostgresPlugin['setupPlugin'] = async (meta) => {
         }
     }
 
+    global.sanitizedSchemaName = sanitizeSqlIdentifier(config.schemaName)
     global.sanitizedTableName = sanitizeSqlIdentifier(config.tableName)
 
     const queryError = await executeQuery(
-        `CREATE TABLE IF NOT EXISTS ${global.sanitizedTableName} (
+        `CREATE TABLE IF NOT EXISTS ${global.sanitizedSchemaName}.${global.sanitizedTableName} (
             uuid varchar(200),
             event varchar(200),
             properties jsonb,
@@ -209,7 +212,7 @@ export const insertBatchIntoPostgres = async (payload: UploadJobPayload, { globa
     )
 
     const queryError = await executeQuery(
-        `INSERT INTO ${global.sanitizedTableName} (uuid, event, properties, elements, set, set_once, distinct_id, team_id, ip, site_url, timestamp)
+        `INSERT INTO ${global.sanitizedSchemaName}.${global.sanitizedTableName} (uuid, event, properties, elements, set, set_once, distinct_id, team_id, ip, site_url, timestamp)
         VALUES ${valuesString}`,
         values,
         config

--- a/plugin.json
+++ b/plugin.json
@@ -50,6 +50,13 @@
             "visible_if": [["databaseUrl", ""]]
         },
         {
+            "key": "schemaName",
+            "name": "Schema name",
+            "type": "string",
+            "default": "public",
+            "hint": "Using a non default schema name needs the schema to be created beforehand, set to public if unsure"
+        },
+        {
             "key": "tableName",
             "name": "Table name",
             "type": "string",


### PR DESCRIPTION
Closes #10 

* correct the algorithm for quoting table names
* add a schema name field, defaulting to `public`
    * the reasoning for having a separate field is that it accepts both schema and table names in unescaped form, so that it can escape both fields separately before concatenation